### PR TITLE
use full width for body

### DIFF
--- a/diapretty/templates/template.html.jinja2
+++ b/diapretty/templates/template.html.jinja2
@@ -138,7 +138,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
 </head>
-<body style="max-width: 1200px">
+<body style="max-width: 100%">
 <header>
     <h1>LocalStack Diagnosis - {{ creation_date }}</h1>
 </header>


### PR DESCRIPTION
This PR changes the max width from `1200px` to `100%` such that it uses the full width of the screen to show the info (which is useful especially for the log messages).