### PR TITLE
add templates to distribution information

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,11 @@ install_requires =
     jinja2
     click
 
+[options.package_data]
+diapretty =
+    templates/**/*.jinja2
+
+
 [options.extras_require]
 dev =
     black>=22.1


### PR DESCRIPTION
This PR updates the `setup.cfg` to make sure templates are included into the python distribution. This is needed if diapretty is used as a dependency.